### PR TITLE
Feature/switch from sqlite3 to postgres for testing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,9 +10,10 @@
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers-community/npm-features/prettier:1": {},
     "terraform": "latest",
-    "ghcr.io/devcontainers/features/aws-cli:1": {}
+    "ghcr.io/devcontainers/features/aws-cli:1": {},
+    "ghcr.io/robbert229/devcontainer-features/postgresql-client:1": {}
   },
-  "runArgs": ["--init", "--privileged"],
+  "runArgs": ["--init", "--privileged", "--network=interview-prep_devnetwork"],
   "remoteUser": "root",
   "mounts": [
     "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached",

--- a/backend/src/knexFile.ts
+++ b/backend/src/knexFile.ts
@@ -21,18 +21,8 @@ const config: { [key: string]: Knex.Config } = {
     },
   },
   test: {
-    client: 'sqlite3',
-    connection: {
-      filename: ':memory:',
-    },
-    pool: {
-      min: 1,
-      max: 1,
-      afterCreate: (conn: any, done: any) => {
-        conn.run('PRAGMA foreign_keys = ON', done);
-      },
-    },
-    useNullAsDefault: true,
+    client: 'pg',
+    connection: process.env['DATABASE_URL'],
     migrations: {
       directory: './migrations',
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+networks:
+  devnetwork:
+
 services:
   frontend:
     build:
@@ -33,7 +36,22 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres-data:/var/lib/postgresql/data # Persist data even after container is removed
+      - postgres-dev-data:/var/lib/postgresql/data # Persist data even after container is removed
+    networks:
+      - devnetwork
+
+  db-test:
+    image: postgres:latest
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-test-data:/var/lib/postgresql/data # Persist data even after container is removed
+    networks:
+      - devnetwork
 
   flyway:
     image: flyway/flyway:latest
@@ -50,6 +68,8 @@ services:
     image: interview-prep-frontend-tests:latest
     working_dir: /app/frontend
     command: npm run test -- --watch=false --browsers=ChromeHeadlessNoSandbox
+    networks:
+      - devnetwork
 
   backend-tests:
     build:
@@ -57,11 +77,16 @@ services:
       dockerfile: backend/Dockerfile
     environment:
       - NODE_ENV=test
-      - DATABASE_URL=postgres://user:password@db:5432/testdb
+      - DATABASE_URL=${DATABASE_URL}
     image: interview-prep-backend-tests:latest
     working_dir: /app/backend
+    depends_on:
+      - db-test
     command: sh -c "npx jest --clearCache && npm run test -- --verbose"
     # command: tail -f /dev/null
+    networks:
+      - devnetwork
 
 volumes:
-  postgres-data:
+  postgres-dev-data:
+  postgres-test-data:


### PR DESCRIPTION
Sqlite3 worked okay, and it was interesting to try out, but it makes sense to use Postgres for testing as it's meant to be the db for production.

I started using a devcontainer and had to set up a network so that the devcontainer could communicate with the db and the tests could run in that environment